### PR TITLE
Update copyright notice and Gmail link

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,7 +351,7 @@
           <button type="submit" id="send-btn" data-i18n="contact_send">Trimite mesajul</button>
         </form>
         <div class="contact-socials">
-          <a href="mailto:business@dporiginalgames.eu" target="_blank"><img src="gmail-icon-transparent-free-png.svg" alt="Email" /></a>
+          <a href="https://mail.google.com/mail/?view=cm&to=business@dporiginalgames.eu" target="_blank"><img src="gmail-icon-transparent-free-png.svg" alt="Email" /></a>
           <a href="https://www.instagram.com/dp.original.games/" target="_blank"><img src="Instagram_logo_2022.svg" alt="Instagram" /></a>
           <a href="https://www.youtube.com/@dp_original" target="_blank"><img src="yt.svg" alt="YouTube" /></a>
           <a href="https://www.tiktok.com/@dp.original.games" target="_blank"><img src="tt.svg" alt="TikTok" /></a>

--- a/translations.js
+++ b/translations.js
@@ -72,7 +72,7 @@ const translations = {
     redirecting_msg: "Redirecting to main page..."
     contact_support: "If you have any issues, contact us at",
     download_copyright: "&copy; 2025 DP Original Games. All rights reserved.",
-    copyright: "© 2025 Daniel Podaru – All rights reserved."
+    copyright: "© 2025 DP Original Games – All rights reserved."
   },
   es: {
     title: "Daniel Podaru - Desarrollador de Juegos",


### PR DESCRIPTION
## Summary
- update copyright notice in translations
- open Gmail compose page when clicking Gmail button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68872e692f54832baf70b2c243e9a577